### PR TITLE
libcusparse v12.5.10.65

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+# build_parameters:
+#   - "--suppress-variables"
+#   #- "--skip-existing"
+#   - "--error-overlinking"
+
+# staging_channel_upload_target: ctk-12.9-build-4
+
+# channels:
+#   - https://staging.continuum.io/pbp/ctk-12.9-build-4

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,9 +1,9 @@
 arm_variant_type: # [aarch64]
   - sbsa          # [linux and aarch64]
-  - tegra         # [linux and aarch64]
+#  - tegra         # [linux and aarch64]
 c_stdlib_version:  # [linux]
-  - 2.17           # [linux and aarch64]
-  - 2.34           # [linux and aarch64]
+  - "2.28"          # [linux and aarch64]
+#  - 2.34           # [linux and aarch64]
 
 zip_keys:               # [linux and aarch64]
   -                     # [linux and aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,12 +2,10 @@
 {% set version = "12.5.10.65" %}
 {% set cuda_version = "12.9" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
-{% set platform = "linux-ppc64le" %}  # [ppc64le]
 {% set platform = "linux-sbsa" %}  # [aarch64 and arm_variant_type=="sbsa"]
 {% set platform = "linux-aarch64" %}  # [aarch64 and arm_variant_type=="tegra"]
 {% set platform = "windows-x86_64" %}  # [win]
 {% set target_name = "x86_64-linux" %}  # [linux64]
-{% set target_name = "ppc64le-linux" %}  # [ppc64le]
 {% set target_name = "sbsa-linux" %}  # [aarch64 and arm_variant_type=="sbsa"]
 {% set target_name = "aarch64-linux" %}  # [aarch64 and arm_variant_type=="tegra"]
 {% set target_name = "x64" %}  # [win]
@@ -26,9 +24,9 @@ source:
   sha256: abb4bfc01198f82fbc956773ccb98c578c03027b6ad425e829355be0c0a11a4a  # [win]
 
 build:
-  number: 2
+  number: 0
   binary_relocation: false
-  skip: true  # [osx or ppc64le]
+  skip: true  # [osx]
 
 requirements:
   build:
@@ -37,6 +35,14 @@ requirements:
 
 outputs:
   - name: libcusparse
+    build:
+      binary_relocation: false
+      missing_dso_whitelist:
+        # Needed for the use of conda-build's --error-overlinking command-line argument
+        - '*libgcc_s.so*'  # [linux]
+      overlinking_ignore_patterns:
+        # Workaround for LIEF's 'not a valid TAG' error
+        - '*libcusparse*.so*'  # [linux and aarch64]
     files:
       - lib/libcusparse.so.*                             # [linux]
       - targets/{{ target_name }}/lib/libcusparse*.so.*  # [linux]
@@ -71,10 +77,12 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: CUDA Sparse Matrix Library
       description: |
         cuSPARSE - Basic Linear Algebra for Sparse Matrices on NVIDIA GPUs
       doc_url: https://docs.nvidia.com/cuda/cusparse/index.html
+      dev_url: https://docs.nvidia.com/cuda/cusparse/index.html
 
   - name: libcusparse-dev
     build:
@@ -124,10 +132,12 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: CUDA Sparse Matrix Library
       description: |
         cuSPARSE - Basic Linear Algebra for Sparse Matrices on NVIDIA GPUs
       doc_url: https://docs.nvidia.com/cuda/cusparse/index.html
+      dev_url: https://docs.nvidia.com/cuda/cusparse/index.html
 
   - name: libcusparse-static
     build:
@@ -155,20 +165,24 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: CUDA Sparse Matrix Library
       description: |
         cuSPARSE - Basic Linear Algebra for Sparse Matrices on NVIDIA GPUs
       doc_url: https://docs.nvidia.com/cuda/cusparse/index.html
+      dev_url: https://docs.nvidia.com/cuda/cusparse/index.html
 
 about:
   home: https://developer.nvidia.com/cusparse
   license_file: LICENSE
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_url: https://docs.nvidia.com/cuda/eula/index.html
+  license_family: Other
   summary: CUDA Sparse Matrix Library
   description: |
     cuSPARSE - Basic Linear Algebra for Sparse Matrices on NVIDIA GPUs
   doc_url: https://docs.nvidia.com/cuda/cusparse/index.html
+  dev_url: https://docs.nvidia.com/cuda/cusparse/index.html
 
 extra:
   feedstock-name: libcusparse


### PR DESCRIPTION
libcusparse 12.5.10.65

**Destination channel:** defaults

### Links

- [PKG-12791](https://anaconda.atlassian.net/browse/PKG-12791) 
- [CUDA 12.9 release notes](https://docs.nvidia.com/cuda/archive/12.9.1/cuda-toolkit-release-notes/index.html) for list of packages, version numbers, etc.

### Explanation of changes:

- CUDA 12.9 release
- Based on upstream feedstock's `12.x` branch.
- Added `abs.yaml` for possible use of staging channels in future builds
- Removed Tegra builds from `cbc.yaml`. We may enable them in the future.
- Kept static library packages as they are dependencies for `cuda-libraries-static` package.


[PKG-12791]: https://anaconda.atlassian.net/browse/PKG-12791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ